### PR TITLE
cd: 11: can't cd to psl1ght/psl1ght

### DIFF
--- a/scripts/011-psl1ght.sh
+++ b/scripts/011-psl1ght.sh
@@ -8,7 +8,7 @@ wget --continue --no-check-certificate https://github.com/HACKERCHANNEL/PSL1GHT/
 rm -Rf psl1ght && mkdir psl1ght && tar --strip-components=1 --directory=psl1ght -xvzf psl1ght.tar.gz || { exit 1; }
 
 ## Create the build directory.
-cd psl1ght/psl1ght || { exit 1; }
+cd psl1ght || { exit 1; }
 
 ## Compile and install.
 make && make install || { exit 1; }


### PR DESCRIPTION
Got this error message when running the script.

"cd: 11: can't cd to psl1ght/psl1ght"

The error can be fixed with changing the path to just "psl1ght" in 011-psl1ght.sh

Have a nice day!
