### PR TITLE
Python dependency

### DIFF
--- a/depends/check-python.sh
+++ b/depends/check-python.sh
@@ -3,3 +3,6 @@
 
 ## Check for python.
 python --version 1> /dev/null || { echo "ERROR: Install python before continuing."; exit 1; }
+
+## Check for python header files
+( ls /usr/include/python2.*/Python.h || ls /opt/local/include/python2.*/Python.h ) 1> /dev/null 2> /dev/null || { echo "ERROR: Install python-dev before continuing."; exit 1; }


### PR DESCRIPTION
Compiling psl1ght without Python headers creates this error message:

```
    gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.6 -c crypt.c -o build/temp.linux-i686-2.6/crypt.o
    crypt.c:1: fatal error: Python.h: No such file or directory
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    make[2]: *** [pkgcrypt.so] Error 1
    make[1]: *** [all] Error 2
    make: *** [all] Error 2
```
