### PR TITLE
Add macOS support

### DIFF
--- a/depends/check-libelf.sh
+++ b/depends/check-libelf.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-libelf.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/libelf.h || ls /usr/local/include/libelf.h || ls /opt/local/include/libelf.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install libelf before continuing."; exit 1; }
+( ls /usr/include/libelf.h || ls /usr/local/include/libelf.h || ls /opt/local/include/libelf.h || ls /usr/local/include/libelf/libelf.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install libelf before continuing."; exit 1; }

--- a/depends/check-ncurses.sh
+++ b/depends/check-ncurses.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-ncurses.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/ncurses.h || ls /usr/include/ncurses/ncurses.h || ls /opt/local/include/ncurses.h || ls /usr/include/curses.h || ls /mingw/include/curses.h) 1>/dev/null 2>&1 || { echo "ERROR: Install ncurses before continuing."; exit 1; }
+( ls /usr/include/ncurses.h || ls /usr/include/ncurses/ncurses.h || ls /opt/local/include/ncurses.h || ls /usr/include/curses.h || ls /mingw/include/curses.h || ls /usr/local/opt/ncurses/include/ncurses.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install ncurses before continuing."; exit 1; }

--- a/depends/check-zlib.sh
+++ b/depends/check-zlib.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-zlib.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/zlib.h || ls /opt/local/include/zlib.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install zlib before continuing."; exit 1; }
+( ls /usr/include/zlib.h || ls /opt/local/include/zlib.h || ls /usr/local/opt/zlib/include/zlib.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install zlib before continuing."; exit 1; }


### PR DESCRIPTION
Adds support for macOS Mojave/Catalina with brew

After installing the required libs/tools using `brew` in a macOS environment, some of the check-dependencies scripts required a fix to validate the installation paths properly.