### PR TITLE
Fix toolchain build on mac os x 10.15

### DIFF
--- a/patches/gdb-7.5.1-PS3.patch
+++ b/patches/gdb-7.5.1-PS3.patch
@@ -1,0 +1,30 @@
+--- gdb-7.5.1.orig/readline/rltty.c	2011-05-12 01:38:39.000000000 +0200
++++ gdb-7.5.1/readline/rltty.c	2021-01-28 17:15:19.470653400 +0100
+@@ -39,7 +39,13 @@
+ 
+ #if defined (GWINSZ_IN_SYS_IOCTL)
+ #  include <sys/ioctl.h>
+-#endif /* GWINSZ_IN_SYS_IOCTL */
++#endif
++
++#ifdef __APPLE__
++int ioctl(int, unsigned long, ...); /* For Darwin, ioctl() is in "sys/ioctl.h",
++                                      but except for special control commands,
++                                      we do not want to include it.  */
++#endif
+ 
+ #include "rltty.h"
+ #include "readline.h"
+--- gdb-7.5.1.orig/readline/terminal.c	2011-05-12 01:38:39.000000000 +0200
++++ gdb-7.5.1/readline/terminal.c	2021-01-28 16:44:32.392817299 +0100
+@@ -55,6 +55,10 @@
+ #  include <sys/ioctl.h>
+ #endif /* GWINSZ_IN_SYS_IOCTL && !TIOCGWINSZ */
+ 
++#ifdef __APPLE__
++#include <sys/ioctl.h>
++#endif
++
+ #ifdef __MSDOS__
+ # include <pc.h>
+ #endif

--- a/patches/psl1ght-PS3.patch
+++ b/patches/psl1ght-PS3.patch
@@ -1,0 +1,71 @@
+diff --git a/psl1ght/tools/cgcomp/Makefile b/psl1ght/tools/cgcomp/Makefile
+index 610a285..1aca3b1 100644
+--- a/psl1ght/tools/cgcomp/Makefile
++++ b/psl1ght/tools/cgcomp/Makefile
+@@ -60,9 +60,9 @@ endif
+
+ ifneq (,$(findstring Darwin,$(UNAME)))
+ 	SDK		:= $(shell xcrun --show-sdk-path)
+-	OSX_MIN		:= $(shell defaults read $(shell xcrun --show-sdk-platform-path)/Info MinimumSDKVersion 2> /dev/null || 10.4)
++	OSX_MIN		:= $(shell defaults read $(shell xcrun --show-sdk-platform-path 2> /dev/null)/Info MinimumSDKVersion 2> /dev/null || xcrun --show-sdk-version 2> /dev/null || echo 10.4)
+ 	OSXCFLAGS	:= -mmacosx-version-min=$(OSX_MIN)
+-	OSXCXXFLAGS	:=	$(OSXCFLAGS)
+-	CXXFLAGS	+=	-fvisibility=hidden
++	OSXCXXFLAGS	:= $(OSXCFLAGS)
++	CXXFLAGS	+= -fvisibility=hidden
+ 	LDFLAGS += -mmacosx-version-min=$(OSX_MIN) -Wl,-syslibroot,$(SDK)
+ endif
+diff --git a/psl1ght/tools/fself/Makefile b/psl1ght/tools/fself/Makefile
+index 1807942..89dd7d7 100644
+--- a/psl1ght/tools/fself/Makefile
++++ b/psl1ght/tools/fself/Makefile
+@@ -47,7 +47,7 @@ endif
+
+ ifneq (,$(findstring Darwin,$(UNAME)))
+ 	SDK			:= $(shell xcrun --show-sdk-path)
+-	OSX_MIN 	:= $(shell defaults read $(shell xcrun --show-sdk-platform-path)/Info MinimumSDKVersion 2> /dev/null || 10.4)
++	OSX_MIN 	:= $(shell defaults read $(shell xcrun --show-sdk-platform-path 2> /dev/null)/Info MinimumSDKVersion 2> /dev/null || xcrun --show-sdk-version 2> /dev/null || echo 10.4)
+ 	OSXCFLAGS	:= -mmacosx-version-min=$(OSX_MIN)
+ 	OSXCXXFLAGS	:=	$(OSXCFLAGS)
+ 	CXXFLAGS	+=	-fvisibility=hidden
+diff --git a/psl1ght/tools/generic/Makefile b/psl1ght/tools/generic/Makefile
+index 0ce8b58..b8e1c5c 100644
+--- a/psl1ght/tools/generic/Makefile
++++ b/psl1ght/tools/generic/Makefile
+@@ -29,7 +29,7 @@ endif
+
+ ifneq (,$(findstring Darwin,$(shell uname -s)))
+ 	SDK	:=	$(shell xcrun --show-sdk-path)
+-	OSX_MIN := $(shell defaults read $(shell xcrun --show-sdk-platform-path)/Info MinimumSDKVersion 2> /dev/null || 10.4)
++	OSX_MIN := $(shell defaults read $(shell xcrun --show-sdk-platform-path 2> /dev/null)/Info MinimumSDKVersion 2> /dev/null || xcrun --show-sdk-version 2> /dev/null || echo 10.4)
+ 	CFLAGS += -mmacosx-version-min=$(OSX_MIN) -isysroot $(SDK) -Wl,-syslibroot,$(SDK)
+ endif
+
+diff --git a/psl1ght/tools/geohot/Makefile b/psl1ght/tools/geohot/Makefile
+index 18086e6..a6e2823 100644
+--- a/psl1ght/tools/geohot/Makefile
++++ b/psl1ght/tools/geohot/Makefile
+@@ -34,7 +34,7 @@ endif
+
+ ifneq (,$(findstring Darwin,$(UNAME)))
+ 	SDK			:= $(shell xcrun --show-sdk-path)
+-	OSX_MIN 	:= $(shell defaults read $(shell xcrun --show-sdk-platform-path)/Info MinimumSDKVersion 2> /dev/null || 10.4)
++	OSX_MIN 	:= $(shell defaults read $(shell xcrun --show-sdk-platform-path 2> /dev/null)/Info MinimumSDKVersion 2> /dev/null || xcrun --show-sdk-version 2> /dev/null || echo 10.4)
+ 	OSXCFLAGS	:= -mmacosx-version-min=$(OSX_MIN)
+ 	OSXCXXFLAGS	:=	$(OSXCFLAGS)
+ 	CXXFLAGS	+=	-fvisibility=hidden
+diff --git a/psl1ght/tools/ps3load/Makefile b/psl1ght/tools/ps3load/Makefile
+index d59ddb8..e05e8cb 100644
+--- a/psl1ght/tools/ps3load/Makefile
++++ b/psl1ght/tools/ps3load/Makefile
+@@ -38,8 +38,8 @@ ifneq (,$(findstring MINGW,$(UNAME)))
+ endif
+
+ ifneq (,$(findstring Darwin,$(shell uname -s)))
+-	SDK	:=	$(shell xcrun --show-sdk-path)
+-	OSX_MIN 	:= $(shell defaults read $(shell xcrun --show-sdk-platform-path)/Info MinimumSDKVersion 2> /dev/null || 10.4)
++	SDK		:= $(shell xcrun --show-sdk-path)
++	OSX_MIN 	:= $(shell defaults read $(shell xcrun --show-sdk-platform-path 2> /dev/null)/Info MinimumSDKVersion 2> /dev/null || xcrun --show-sdk-versin 2> /dev/null || echo 10.4)
+ 	OSXCFLAGS	:= -mmacosx-version-min=$(OSX_MIN) -isysroot $(SDK)
+ 	OSXCXXFLAGS	:=	$(OSXCFLAGS)
+ 	CXXFLAGS	+=	-fvisibility=hidden

--- a/scripts/003-gdb-PPU.sh
+++ b/scripts/003-gdb-PPU.sh
@@ -15,6 +15,9 @@ if [ ! -d ${GDB} ]; then
   ## Unpack the source code.
   tar xfvj ${GDB}.tar.bz2
 
+  ## Patch the source code
+  cat ../patches/${GDB}-PS3.patch | patch -p1 -d ${GDB}
+
   ## Replace config.guess and config.sub
   cp config.guess config.sub ${GDB}
 

--- a/scripts/008-psl1ght.sh
+++ b/scripts/008-psl1ght.sh
@@ -7,7 +7,13 @@ wget --no-check-certificate https://github.com/ps3dev/PSL1GHT/tarball/master -O 
 ## Unpack the source code.
 rm -Rf psl1ght && mkdir psl1ght && tar --strip-components=1 --directory=psl1ght -xvzf psl1ght.tar.gz
 
-## Create the build directory.
+# Convert file to unix line endings
+dos2unix psl1ght/tools/fself/Makefile
+
+# Patch for building on Mac os X
+cat ../patches/psl1ght-PS3.patch | patch -p2 -d psl1ght
+
+## Enter the build directory.
 cd psl1ght
 
 ## Compile and install.


### PR DESCRIPTION
This pull requests fixes builds with the gdb and psl1ight.
The latter should likely be fixed upstream. 

See https://github.com/ps3dev/PSL1GHT/issues/121