### PR TITLE
Add lib paths on Apple M1 (arm64)

### DIFF
--- a/depends/check-gmp.sh
+++ b/depends/check-gmp.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-gmp.sh by Timothy Redaelli (timothy@redaelli.eu)
 
-( pkg-config --exists gmp ) || { echo "ERROR: Install gmp before continuing."; exit 1; }
+[ -f /usr/include/$(gcc -dumpmachine)/gmp.h -o -f /usr/include/gmp.h -o -f /opt/local/include/gmp.h -o -f /usr/local/include/gmp.h -o -f /opt/csw/include/gmp.h ] || pkg-config --exists gmp || { echo "ERROR: Install gmp before continuing."; exit 1; }

--- a/depends/check-gmp.sh
+++ b/depends/check-gmp.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-gmp.sh by Timothy Redaelli (timothy@redaelli.eu)
 
-[ -f /usr/include/$(gcc -dumpmachine)/gmp.h -o -f /usr/include/gmp.h -o -f /opt/local/include/gmp.h -o -f /opt/homebrew/include/gmp.h -o -f /usr/local/include/gmp.h -o -f /opt/csw/include/gmp.h ] || { echo "ERROR: Install gmp before continuing."; exit 1; }
+( pkg-config --exists gmp ) || { echo "ERROR: Install gmp before continuing."; exit 1; }

--- a/depends/check-gmp.sh
+++ b/depends/check-gmp.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-gmp.sh by Timothy Redaelli (timothy@redaelli.eu)
 
-[ -f /usr/include/$(gcc -dumpmachine)/gmp.h -o -f /usr/include/gmp.h -o -f /opt/local/include/gmp.h -o -f /usr/local/include/gmp.h -o -f /opt/csw/include/gmp.h ] || { echo "ERROR: Install gmp before continuing."; exit 1; }
+[ -f /usr/include/$(gcc -dumpmachine)/gmp.h -o -f /usr/include/gmp.h -o -f /opt/local/include/gmp.h -o -f /opt/homebrew/include/gmp.h -o -f /usr/local/include/gmp.h -o -f /opt/csw/include/gmp.h ] || { echo "ERROR: Install gmp before continuing."; exit 1; }

--- a/depends/check-libelf.sh
+++ b/depends/check-libelf.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-libelf.sh by Naomi Peori (naomi@peori.ca)
 
-( pkg-config --exists libelf ) || { echo "ERROR: Install libelf before continuing."; exit 1; }
+( ls /usr/include/libelf.h || ls /usr/local/include/libelf.h || ls /opt/local/include/libelf.h || ls /opt/local/include/libelf/libelf.h || ls /usr/local/include/libelf/libelf.h ) 1>/dev/null 2>&1 || pkg-config --exists libelf || { echo "ERROR: Install libelf before continuing."; exit 1; }

--- a/depends/check-libelf.sh
+++ b/depends/check-libelf.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-libelf.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/libelf.h || ls /usr/local/include/libelf.h || ls /opt/local/include/libelf.h || ls /opt/local/include/libelf/libelf.h || ls /usr/local/include/libelf/libelf.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install libelf before continuing."; exit 1; }
+( ls /usr/include/libelf.h || ls /usr/local/include/libelf.h || ls /opt/local/include/libelf.h || ls /opt/local/include/libelf/libelf.h || ls /opt/homebrew/include/libelf/libelf.h || ls /usr/local/include/libelf/libelf.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install libelf before continuing."; exit 1; }

--- a/depends/check-libelf.sh
+++ b/depends/check-libelf.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-libelf.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/libelf.h || ls /usr/local/include/libelf.h || ls /opt/local/include/libelf.h || ls /opt/local/include/libelf/libelf.h || ls /opt/homebrew/include/libelf/libelf.h || ls /usr/local/include/libelf/libelf.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install libelf before continuing."; exit 1; }
+( pkg-config --exists libelf ) || { echo "ERROR: Install libelf before continuing."; exit 1; }

--- a/depends/check-ncurses.sh
+++ b/depends/check-ncurses.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-ncurses.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/ncurses.h || ls /usr/include/ncurses/ncurses.h || ls /opt/local/include/ncurses.h || ls /opt/homebrew/opt/ncurses/include/ncurses.h || ls /usr/include/curses.h || ls /mingw/include/curses.h || ls /usr/local/opt/ncurses/include/ncurses.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install ncurses before continuing."; exit 1; }
+( pkg-config --exists ncurses ) || { echo "ERROR: Install ncurses before continuing."; exit 1; }

--- a/depends/check-ncurses.sh
+++ b/depends/check-ncurses.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-ncurses.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/ncurses.h || ls /usr/include/ncurses/ncurses.h || ls /opt/local/include/ncurses.h || ls /usr/include/curses.h || ls /mingw/include/curses.h || ls /usr/local/opt/ncurses/include/ncurses.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install ncurses before continuing."; exit 1; }
+( ls /usr/include/ncurses.h || ls /usr/include/ncurses/ncurses.h || ls /opt/local/include/ncurses.h || ls /opt/homebrew/opt/ncurses/include/ncurses.h || ls /usr/include/curses.h || ls /mingw/include/curses.h || ls /usr/local/opt/ncurses/include/ncurses.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install ncurses before continuing."; exit 1; }

--- a/depends/check-ncurses.sh
+++ b/depends/check-ncurses.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-ncurses.sh by Naomi Peori (naomi@peori.ca)
 
-( pkg-config --exists ncurses ) || { echo "ERROR: Install ncurses before continuing."; exit 1; }
+( ls /usr/include/ncurses.h || ls /usr/include/ncurses/ncurses.h || ls /opt/local/include/ncurses.h || ls /usr/include/curses.h || ls /mingw/include/curses.h || ls /usr/local/opt/ncurses/include/ncurses.h ) 1>/dev/null 2>&1 || pkg-config --exists ncurses || { echo "ERROR: Install ncurses before continuing."; exit 1; }

--- a/depends/check-zlib.sh
+++ b/depends/check-zlib.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-zlib.sh by Naomi Peori (naomi@peori.ca)
 
-( pkg-config --exists zlib ) || { echo "ERROR: Install zlib before continuing."; exit 1; }
+( ls /usr/include/zlib.h || ls /opt/local/include/zlib.h || ls /usr/local/opt/zlib/include/zlib.h ) 1>/dev/null 2>&1 || pkg-config --exists zlib || { echo "ERROR: Install zlib before continuing."; exit 1; }

--- a/depends/check-zlib.sh
+++ b/depends/check-zlib.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-zlib.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/zlib.h || ls /opt/local/include/zlib.h || ls /usr/local/opt/zlib/include/zlib.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install zlib before continuing."; exit 1; }
+( ls /usr/include/zlib.h || ls /opt/local/include/zlib.h || ls /opt/homebrew/opt/zlib/include/zlib.h || ls /usr/local/opt/zlib/include/zlib.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install zlib before continuing."; exit 1; }

--- a/depends/check-zlib.sh
+++ b/depends/check-zlib.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # check-zlib.sh by Naomi Peori (naomi@peori.ca)
 
-( ls /usr/include/zlib.h || ls /opt/local/include/zlib.h || ls /opt/homebrew/opt/zlib/include/zlib.h || ls /usr/local/opt/zlib/include/zlib.h ) 1>/dev/null 2>&1 || { echo "ERROR: Install zlib before continuing."; exit 1; }
+( pkg-config --exists zlib ) || { echo "ERROR: Install zlib before continuing."; exit 1; }


### PR DESCRIPTION
This PR updates the checks to build the ps3 toolchain on macOS w/ Apple M1 processors.

Note: Homebrew package manager install libs on `/opt/homebrew/` when running on Apple M1 (arm64)