### PR TITLE
Replaced dead URLs with links to supported mirrors 

### DIFF
--- a/scripts/001-binutils-PPU.sh
+++ b/scripts/001-binutils-PPU.sh
@@ -6,7 +6,7 @@ BINUTILS="binutils-2.22"
 if [ ! -d ${BINUTILS} ]; then
 
   ## Download the source code.
-  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue https://ftp.gnu.org/gnu/binutils/${BINUTILS}.tar.bz2; fi
+  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue http://ftpmirror.gnu.org/binutils/${BINUTILS}.tar.bz2; fi
 
   ## Download an up-to-date config.guess and config.sub
   if [ ! -f config.guess ]; then wget --continue https://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi

--- a/scripts/001-binutils-PPU.sh
+++ b/scripts/001-binutils-PPU.sh
@@ -6,7 +6,7 @@ BINUTILS="binutils-2.22"
 if [ ! -d ${BINUTILS} ]; then
 
   ## Download the source code.
-  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue http://ftpmirror.gnu.org/binutils/${BINUTILS}.tar.bz2; fi
+  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue https://ftpmirror.gnu.org/binutils/${BINUTILS}.tar.bz2; fi
 
   ## Download an up-to-date config.guess and config.sub
   if [ ! -f config.guess ]; then wget --continue https://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi

--- a/scripts/002-gcc-newlib-PPU.sh
+++ b/scripts/002-gcc-newlib-PPU.sh
@@ -7,7 +7,7 @@ NEWLIB="newlib-1.20.0"
 if [ ! -d ${GCC} ]; then
 
   ## Download the source code.
-  if [ ! -f ${GCC}.tar.xz ]; then wget --continue https://ftp.gnu.org/gnu/gcc/${GCC}/${GCC}.tar.xz; fi
+  if [ ! -f ${GCC}.tar.xz ]; then wget --continue https://ftpmirror.gnu.org/gnu/gcc/${GCC}/${GCC}.tar.xz; fi
   if [ ! -f ${NEWLIB}.tar.gz ]; then wget --continue https://sourceware.org/pub/newlib/${NEWLIB}.tar.gz; fi
 
   ## Unpack the source code.

--- a/scripts/003-gdb-PPU.sh
+++ b/scripts/003-gdb-PPU.sh
@@ -6,7 +6,7 @@ GDB="gdb-8.3.1"
 if [ ! -d ${GDB} ]; then
 
   ## Download the source code.
-  if [ ! -f ${GDB}.tar.xz ]; then wget --continue https://ftp.gnu.org/gnu/gdb/${GDB}.tar.xz; fi
+  if [ ! -f ${GDB}.tar.xz ]; then wget --continue https://ftpmirror.gnu.org/gnu/gdb/${GDB}.tar.xz; fi
 
   ## Download an up-to-date config.guess and config.sub
   if [ ! -f config.guess ]; then wget --continue https://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi

--- a/scripts/005-binutils-SPU.sh
+++ b/scripts/005-binutils-SPU.sh
@@ -6,7 +6,7 @@ BINUTILS="binutils-2.22"
 if [ ! -d ${BINUTILS} ]; then
 
   ## Download the source code.
-  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue https://ftp.gnu.org/gnu/binutils/${BINUTILS}.tar.bz2; fi
+  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue http://ftpmirror.gnu.org/binutils/${BINUTILS}.tar.bz2; fi
 
   ## Download an up-to-date config.guess and config.sub
   if [ ! -f config.guess ]; then wget --continue https://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi

--- a/scripts/005-binutils-SPU.sh
+++ b/scripts/005-binutils-SPU.sh
@@ -6,7 +6,7 @@ BINUTILS="binutils-2.22"
 if [ ! -d ${BINUTILS} ]; then
 
   ## Download the source code.
-  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue http://ftpmirror.gnu.org/binutils/${BINUTILS}.tar.bz2; fi
+  if [ ! -f ${BINUTILS}.tar.bz2 ]; then wget --continue https://ftpmirror.gnu.org/binutils/${BINUTILS}.tar.bz2; fi
 
   ## Download an up-to-date config.guess and config.sub
   if [ ! -f config.guess ]; then wget --continue https://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi

--- a/scripts/006-gcc-newlib-SPU.sh
+++ b/scripts/006-gcc-newlib-SPU.sh
@@ -7,7 +7,7 @@ NEWLIB="newlib-1.20.0"
 if [ ! -d ${GCC} ]; then
 
   ## Download the source code.
-  if [ ! -f ${GCC}.tar.xz ]; then wget --continue https://ftp.gnu.org/gnu/gcc/${GCC}/${GCC}.tar.xz; fi
+  if [ ! -f ${GCC}.tar.xz ]; then wget --continue https://ftpmirror.gnu.org/gnu/gcc/${GCC}/${GCC}.tar.xz; fi
   if [ ! -f ${NEWLIB}.tar.gz ]; then wget --continue https://sourceware.org/pub/newlib/${NEWLIB}.tar.gz; fi
 
   ## Unpack the source code.

--- a/scripts/007-gdb-SPU.sh
+++ b/scripts/007-gdb-SPU.sh
@@ -6,7 +6,7 @@ GDB="gdb-8.3.1"
 if [ ! -d ${GDB} ]; then
 
   ## Download the source code.
-  if [ ! -f ${GDB}.tar.xz ]; then wget --continue https://ftp.gnu.org/gnu/gdb/${GDB}.tar.xz; fi
+  if [ ! -f ${GDB}.tar.xz ]; then wget --continue https://ftpmirror.gnu.org/gnu/gdb/${GDB}.tar.xz; fi
 
   ## Download an up-to-date config.guess and config.sub
   if [ ! -f config.guess ]; then wget --continue https://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi

--- a/scripts/009-ps3libraries.sh
+++ b/scripts/009-ps3libraries.sh
@@ -2,7 +2,7 @@
 # ps3libraries.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --no-check-certificate https://github.com/ps3dev/ps3libraries/tarball/master -O ps3libraries.tar.gz
+wget --no-check-certificate https://github.com/DerQut/ps3libraries/tarball/master -O ps3libraries.tar.gz
 
 ## Unpack the source code.
 rm -Rf ps3libraries && mkdir ps3libraries && tar --strip-components=1 --directory=ps3libraries -xvzf ps3libraries.tar.gz && cd ps3libraries

--- a/scripts/009-ps3libraries.sh
+++ b/scripts/009-ps3libraries.sh
@@ -2,7 +2,7 @@
 # ps3libraries.sh by Naomi Peori (naomi@peori.ca)
 
 ## Download the source code.
-wget --no-check-certificate https://github.com/DerQut/ps3libraries/tarball/master -O ps3libraries.tar.gz
+wget --no-check-certificate https://github.com/ps3dev/ps3libraries/tarball/master -O ps3libraries.tar.gz
 
 ## Unpack the source code.
 rm -Rf ps3libraries && mkdir ps3libraries && tar --strip-components=1 --directory=ps3libraries -xvzf ps3libraries.tar.gz && cd ps3libraries


### PR DESCRIPTION
Changed the given script files:

- scripts/001-binutils-PPU.sh
- scripts/002-gcc-newlib-PPU.sh
- scripts/003-gdb-PPU.sh
- scripts/005-binutils-SPU.sh
- scripts/006-gcc-newlib-SPU.sh
- scripts/007-gdb-SPU.sh

to point to a supported GNU mirror (https://ftpmirror.gnu.org) rather than https://ftp.gnu.org, which has lost support and is no longer accessible