### PR TITLE
Build ps3 toolchain only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
 
     - name: Runs all the stages in the shell
       if: matrix.os == 'ubuntu-latest'
+      shell: bash -e {0}
+      env:
+        BUILD_PS3TOOLCHAIN_ONLY: 1
       run: |
         mkdir $PWD/ps3dev
         export PS3DEV=$PWD/ps3dev
@@ -47,6 +50,8 @@ jobs:
     - name: Runs all the stages in the shell
       if: matrix.os == 'macos-15-intel'
       shell: arch -x86_64 bash -e {0}
+      env:
+        BUILD_PS3TOOLCHAIN_ONLY: 1
       run: |
         mkdir $PWD/ps3dev
         export PS3DEV=$PWD/ps3dev

--- a/scripts/008-psl1ght.sh
+++ b/scripts/008-psl1ght.sh
@@ -4,6 +4,12 @@
 ## Download the source code.
 wget --no-check-certificate https://github.com/ps3dev/PSL1GHT/tarball/master -O psl1ght.tar.gz
 
+## Check if we want to skip this step
+if [[ -n "$BUILD_PS3TOOLCHAIN_ONLY" ]]; then
+    echo "PS3 Toolchain only set. Skipping..."
+    exit 0
+fi
+
 ## Unpack the source code.
 rm -Rf psl1ght && mkdir psl1ght && tar --strip-components=1 --directory=psl1ght -xvzf psl1ght.tar.gz
 

--- a/scripts/009-ps3libraries.sh
+++ b/scripts/009-ps3libraries.sh
@@ -4,6 +4,12 @@
 ## Download the source code.
 wget --no-check-certificate https://github.com/ps3dev/ps3libraries/tarball/master -O ps3libraries.tar.gz
 
+## Check if we want to skip this step
+if [[ -n "$BUILD_PS3TOOLCHAIN_ONLY" ]]; then
+    echo "PS3 Toolchain only set. Skipping..."
+    exit 0
+fi
+
 ## Unpack the source code.
 rm -Rf ps3libraries && mkdir ps3libraries && tar --strip-components=1 --directory=ps3libraries -xvzf ps3libraries.tar.gz && cd ps3libraries
 


### PR DESCRIPTION
if env var `BUILD_PS3TOOLCHAIN_ONLY` is set,
- skip psl1ght
- skip ps3libraries