### PR TITLE
Fix macOS setup command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For RedHat distros:
   be enough to install everything necessary:
 
 ```bash
-  brew install autoconf automake openssl libelf ncurses zlib gmp wget pkg-config
+  brew install autoconf automake openssl libelf ncurses zlib gmp wget pkg-config texinfo
 ```
 
 ## Add the following variables to your bash config:


### PR DESCRIPTION
Add `texinfo` to macOS Homebrew install command. This aligns with #140 and helps fix `ERROR: Install makeinfo before continuing` on macOS.