### PR TITLE
Add python3 checks in check-python.sh

### DIFF
--- a/depends/check-python.sh
+++ b/depends/check-python.sh
@@ -2,7 +2,7 @@
 # check-python.sh by Naomi Peori (naomi@peori.ca)
 
 ## Check for python.
-( python --version || python -V ) 1>/dev/null 2>&1 || { echo "ERROR: Install python before continuing."; exit 1; }
+( python --version || python -V || python3 --version || python3 -V ) 1>/dev/null 2>&1 || { echo "ERROR: Install python before continuing."; exit 1; }
 
 ## Check for python-config
 pyprefix=$(python-config --prefix || python3-config --prefix)


### PR DESCRIPTION
macOS native python only provides `python3` command.
This approach is similar to da6f4e062f6c2177b2a6f68fd50c494ccc13689d.