### PR TITLE
Fix utils.sh typo

### DIFF
--- a/scripts/008-psl1ght.sh
+++ b/scripts/008-psl1ght.sh
@@ -8,7 +8,7 @@ if [ -n "$BUILD_PS3TOOLCHAIN_ONLY" ]; then
     exit 0
 fi
 
-source ../utils/util.sh
+source ../utils/utils.sh
 
 ## Download the source code.
 ../download.sh psl1ght.tar.gz

--- a/scripts/009-ps3libraries.sh
+++ b/scripts/009-ps3libraries.sh
@@ -8,7 +8,7 @@ if [ -n "$BUILD_PS3TOOLCHAIN_ONLY" ]; then
     exit 0
 fi
 
-source ../utils/util.sh
+source ../utils/utils.sh
 
 ## Download the source code.
 ../download.sh ps3libraries.tar.gz


### PR DESCRIPTION
This one is straighforward:
```
./toolchain.sh 8
  >>> Running:
  >>> Running:
  >>> Running:
  >>> Running:
  >>> Running:
  >>> Running:
  >>> Running: ../scripts/008-psl1ght.sh
  ../scripts/008-psl1ght.sh: line 11: ../utils/util.sh: No such file or directory
  ../scripts/008-psl1ght.sh: Failed.
```